### PR TITLE
Remove build badge provided by Travis CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # Kintoki
 
-[![Build Status](https://travis-ci.com/WorksApplications/kintoki.svg?branch=develop)](https://travis-ci.com/WorksApplications/kintoki)
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=com.worksap.nlp%3Akintoki&metric=alert_status)](https://sonarcloud.io/dashboard?id=com.worksap.nlp%3Akintoki)
 
 Kintoki is a dependency parser library.


### PR DESCRIPTION
This repository does not use Travis CI at this moment.
So the build badge is not working. Simply remove it from the README.